### PR TITLE
Maintenance: Adhere to new Azure methodology

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -59,6 +59,13 @@ az storage container create --name "uploads" \
     --resource-group $RG_NAME
 STORAGE_KEY=$(az storage account keys list --resource-group $RG_NAME --account-name $STORAGE_NAME --output tsv --query '[0].value' | tr -d '\r\n')
 
+# avoid ManagedEnvironmentSubnetDelegationError by specifying subnet delegation
+az network vnet subnet update \
+  --resource-group $RG_NAME \
+  --vnet-name $VNET_NAME \
+  --name subnet-capps \
+  --delegations Microsoft.App/environments
+
 # create azure container apps environment and deploy our container
 az containerapp env create --name $CONTAINERAPP_ENV \
     --resource-group $RG_NAME \

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,15 +18,16 @@ WORDPRESS_USERNAME=wpuser
 WORDPRESS_PASSWORD=$(tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' < /dev/urandom | head -c 15 ; echo)
 MYSQL_SERVER_NAME=wordpressmysql-$id
 STORAGE_NAME=sawordpress$id
+VNET_NAME=vnet-wordpress
 
 # create rg
 az group create --name $RG_NAME --location $LOCATION
 
 # create vnet and 2 subnets (one for Wordpress and one for our DB)
-az network vnet create --name vnet-wordpress --resource-group $RG_NAME --location $LOCATION
-az network vnet subnet create --resource-group $RG_NAME --vnet-name vnet-wordpress --name subnet-capps --address-prefixes 10.0.0.0/23
-az network vnet subnet create --resource-group $RG_NAME --vnet-name vnet-wordpress --name subnet-db --address-prefixes 10.0.2.0/28
-capps_id=$(az network vnet subnet show --vnet-name vnet-wordpress --resource-group $RG_NAME --name subnet-capps --output tsv --query 'id' | tr -d '\r\n')
+az network vnet create --name $VNET_NAME --resource-group $RG_NAME --location $LOCATION
+az network vnet subnet create --resource-group $RG_NAME --vnet-name $VNET_NAME --name subnet-capps --address-prefixes 10.0.0.0/23
+az network vnet subnet create --resource-group $RG_NAME --vnet-name $VNET_NAME --name subnet-db --address-prefixes 10.0.2.0/28
+capps_id=$(az network vnet subnet show --vnet-name $VNET_NAME --resource-group $RG_NAME --name subnet-capps --output tsv --query 'id' | tr -d '\r\n')
 
 # create azure container registry
 az acr create --name $ACR_NAME --resource-group $RG_NAME --sku Basic --admin-enabled true
@@ -45,7 +46,7 @@ az mysql flexible-server create --location $LOCATION --resource-group $RG_NAME \
     --version 5.7 \
     --storage-auto-grow Enabled \
     --database-name wordpress \
-    --vnet vnet-wordpress --subnet subnet-db \
+    --vnet $VNET_NAME --subnet subnet-db \
     --yes
 
 # create azure storage account, a blob and extract primary access key

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ capps_id=$(az network vnet subnet show --vnet-name vnet-wordpress --resource-gro
 az acr create --name $ACR_NAME --resource-group $RG_NAME --sku Basic --admin-enabled true
 ACR_USERNAME=$(az acr credential show --name $ACR_NAME --output tsv --query "username" | tr -d '\r\n')
 ACR_PASSWORD=$(az acr credential show --name $ACR_NAME --output tsv --query "passwords[0].value" | tr -d '\r\n')
-az acr login --name $ACR_NAME --username $ACR_USERNAME --password $ACR_PASSWORD
+az acr login --name $ACR_NAME --expose-token
 
 # build & push docker image
 az acr build --registry $ACR_NAME --image $IMAGE_NAME --file Dockerfile .


### PR DESCRIPTION
Fixes 2 issues that prevent functionality in the current Azure environment and adds 1 quality of life feature.

1. The --username --password login type for ACR in Azure Shell is not supported when using docker daemon. Changed to --expose-token

2. The container apps subnet must now have an explicitly assigned delgate or a fatal error will occur. Added the appropriate code

3. (QoL) Added a variable for the VNet name, as this was the only resource that did not have a customizable name

Tested with successful outcome on Azure Shell.